### PR TITLE
Make the header on rsvp page link back to index.html

### DIFF
--- a/rsvp.html
+++ b/rsvp.html
@@ -19,12 +19,12 @@
   <header>
     <div class="header-width">
       <div class="yellow-box">
-        <div class="logotype"></div>
-        <div class="skyline"></div>
-        <div class="tagline">A monthly JavaScript meet up in Los Angeles.</div>
+        <a href="index.html"><div class="logotype"></div></a>
+        <a href="index.html"><div class="skyline"></div></a>
+        <a href="index.html"><div class="tagline">A monthly JavaScript meet up in Los Angeles.</div></a>
       </div>
     </div>
-    
+
     <div class="navigation">
       <div class="navigation-width">
         <a class="current" href="index.html">Upcoming Events</a>


### PR DESCRIPTION
Noticed that the rsvp page header wasn't linking back to the index page. 
