### PR TITLE
Fixing a bug with overlapping images

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,8 +44,8 @@
     </a>
     
     <div class="sponsors-2x">
-      <a href="http://spire.io" target="_blank"><img src="./images/hosts/sponsor-spire.png"></a>
-      <a href="http://crosscamp.us" target="_blank"><img src="./images/hosts/crosscampus.png"></a>
+      <a href="http://spire.io" target="_blank" style="float:left"><img src="./images/hosts/sponsor-spire.png"></a>
+      <a href="http://crosscamp.us" target="_blank" style="float:right"><img src="./images/hosts/crosscampus.png"></a>
     </div>
 
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,5 +1,6 @@
 html {
   height: 100%;
+  width: 100%;
 }
 
 body {
@@ -258,7 +259,7 @@ header {
 }
 
 .sponsors-2x {
-  width: 864px;
+  width: 890px;
   height: 148px;
   margin: 36px auto;
   margin-bottom: 70px;
@@ -275,7 +276,7 @@ sponsors a, .sponsors-2x a {
 .sponsors img, .sponsors-2x img {
   box-shadow: 0px 0px 5px #777;
   border-radius: 10px;
-  margin: 10px;
+  margin: 5px;
 }
 
 .sponsors-2x img:hover {


### PR DESCRIPTION
On Safari and some Chromes there was visual wonkiness with regards to the sponsors
