### PR TITLE
Sponsor link was broken on "Upcoming event"

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,8 +44,8 @@
     </a>
     
     <div class="sponsors-2x">
-      <a href="http://spire.io" target="_blank" style="float:left"><img src="./images/hosts/iola.png"></a>
-      <a href="http://crosscamp.us" target="_blank" style="float:right"><img src="./images/hosts/sponsor-spire.png"></a>
+      <a href="http://iola.la" target="_blank" style="float:left"><img src="./images/hosts/iola.png"></a>
+      <a href="http://spire.io" target="_blank" style="float:right"><img src="./images/hosts/sponsor-spire.png"></a>
     </div>
 
 


### PR DESCRIPTION
Now io/LA points to the correct url destination.
