### PR TITLE
Added padding to align current speaker anchor properly

### DIFF
--- a/public/css/src/component/speakers.less
+++ b/public/css/src/component/speakers.less
@@ -1,3 +1,7 @@
+.jsla-current-event {
+    padding-top: 35px;
+}
+
 .jsla-speakers-list {
     list-style-type: none;
     padding: 0;


### PR DESCRIPTION
Tested in latest Chrome/FF/Safari/IE. This just aligns the anchor to compensate for the nagivation bar being fixed at 31px in height. Cheers.