### PR TITLE
Create speaker image script via npm run command. Updates readme for usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,7 @@ Everything will rebuild automatically except for the Javascript that you will ne
 
     $ npm run build
 
-## notes
+If you need to create a speaker avatar, we normalize them to be 160x160. Run the command on an existing image that hasn't been converted yet like so
 
-Right now we do not have a script to resize images maybe in to future :), but the simpliest way to do it is to have (imagemagick)[http://www.imagemagick.org/] installed. Then run this command on avatars.
+    $ npm run speakerimages -- --imagepath=public/images/speakers/avatarname.jpeg
 
-```shell
- convert ${SPEAKERDIR}/${USERNAME}.${FILE_EXT} -resize 160x160^ -gravity center -extent 160x160 ${SPEAKERDIR}/${USERNAME}.jpg
-```
-
-Then replace those variables with the correct location of the speakers avatars, and the username of the speaker. This will require you to have already placed the avatar in the that directory. Also the old file if its not overwritten should be removed. The size is 160x160 because the largest display size is 80 and 2x dpi would be 160.

--- a/bin/convert-speaker-images.js
+++ b/bin/convert-speaker-images.js
@@ -1,0 +1,39 @@
+#! /usr/bin/env node
+
+var argv = require('minimist')(process.argv.slice(2))
+    , lwip = require('lwip')
+    , path = require('path')
+
+function print(msg) {
+    console.log(msg + '\n')
+} 
+
+function usage() {
+    print('Usage:')
+    print('npm run speakerimages -- --imagepath=<path/to/file/name.jpeg>')
+}
+
+// main
+if (!argv.imagepath) {
+    print('Missing script arguments')
+    usage()
+} else {
+    var filePath = path.resolve(__dirname + '/../' + argv.imagepath)
+        , pathParts = filePath.split('/')
+        // everything but the file name
+        , pathBase = pathParts.slice(0, -1)
+        , fileName = pathParts.slice(-1)
+        , convertPath = path.resolve(pathBase.join('/') + '/' + fileName[0].split('.')[0] + '.jpg')
+
+    // resizes and crops keeping ratio without skewing
+    lwip.open(filePath, function(err, image){
+        if (err) throw err
+
+        image.batch()
+            .cover(160, 160)
+            .writeFile(convertPath, { quality: 75 }, function(err) {
+                if (err) throw err
+                print('Done converting file: ' + convertPath)
+            })
+    })
+}

--- a/bin/convert-speaker-images.js
+++ b/bin/convert-speaker-images.js
@@ -18,12 +18,12 @@ if (!argv.imagepath) {
     print('Missing script arguments')
     usage()
 } else {
-    var filePath = path.resolve(__dirname + '/../' + argv.imagepath)
+    var filePath = path.normalize(__dirname + '/../' + argv.imagepath)
         , pathParts = filePath.split('/')
         // everything but the file name
         , pathBase = pathParts.slice(0, -1)
         , fileName = pathParts.slice(-1)
-        , convertPath = path.resolve(pathBase.join('/') + '/' + fileName[0].split('.')[0] + '.jpg')
+        , convertPath = path.normalize(pathBase.join('/') + '/' + fileName[0].split('.')[0] + '.jpg')
 
     // resizes and crops keeping ratio without skewing
     lwip.open(filePath, function(err, image){

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "browserify public/js/main.js -o public/js/bundle.js -d && npm run compress",
     "compress": "uglifyjs -o public/js/bundle.min.js public/js/bundle.js",
     "dist": "rm -rf ./dist; harp compile ./public dist",
-    "deploy": "npm run dist && echo 'js.la' > dist/CNAME && surge dist"
+    "deploy": "npm run dist && echo 'js.la' > dist/CNAME && surge dist",
+    "speakerimages": "node bin/convert-speaker-images.js"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,8 @@
   "devDependencies": {
     "browserify": "^11.1.0",
     "harp": "^0.19.0",
+    "lwip": "0.0.8",
+    "minimist": "^1.2.0",
     "surge": "^0.14.4",
     "uglify-js": "^2.3.6"
   },


### PR DESCRIPTION
This creates the speaker image script that was marked as a *note* from the readme. 

## Features

- If it needs to be expanded later, the script takes in named flags. For now there is just `--imagepath`. 
- It keeps the aspect ratio and doesn't skew it, similar to what the `-extent` flag did with `imagemagick`

## Usage
```
$ npm run speakerimages -- --imagepath=public/images/speakers/robbie-dela-victoria.jpeg
```

## Output
```
> node bin/convert-speaker-images.js "--imagepath=public/images/speakers/robbie-dela-victoria.jpeg"

Done converting file: /Users/ryan.regalado/Dev/repos/js.la/public/images/speakers/robbie-dela-victoria.jpg
```


### Sample with usage output
```
$ npm run speakerimages --

> js.la@0.0.1 speakerimages /Users/ryan.regalado/Dev/repos/js.la
> node bin/convert-speaker-images.js

Missing script arguments

Usage:

npm run speakerimages -- --imagepath=<path/to/file/name.jpeg>
```