### PR TITLE
Styling fixes for the margins on the Sponsorship page and Faq page

### DIFF
--- a/public/faq.jade
+++ b/public/faq.jade
@@ -1,37 +1,38 @@
 div.jsla-toplevel-container.jsla-content-page
-    h1
-        strong Frequently Asked Questions
-    hr
+    div.jsla-content-section.layer-2
+        h1
+            strong Frequently Asked Questions
+        hr
 
-    h3#whoRunsJsla Who runs js.la?
-    p A team of dedicated and community loving folks whom you can find more about on the <a href="/team">team</a> page.
+        h3#whoRunsJsla Who runs js.la?
+        p A team of dedicated and community loving folks whom you can find more about on the <a href="/team">team</a> page.
 
-    h3#whatIsJsla What is js.la?
-    p js.la runs events that bring you the best speakers talking about JavaScript and related internet technologies, as well as educational workshops like <a href="https://nodeschool.io/los-angeles/">NodeSchool</a> and general gatherigs like <a href="http://lunch.js.la/">lunch.js</a>.
+        h3#whatIsJsla What is js.la?
+        p js.la runs events that bring you the best speakers talking about JavaScript and related internet technologies, as well as educational workshops like <a href="https://nodeschool.io/los-angeles/">NodeSchool</a> and general gatherigs like <a href="http://lunch.js.la/">lunch.js</a>.
 
-    h3#whenIsJsla When is js.la?
-    p The main event is always on the last Thursday of every month! You can always go to our homepage at <a href="/">js.la</a> to find out about the next one.
-    p <a href="https://nodeschool.io/los-angeles/">NodeSchool</a> is on the first Saturday of every month.
-    p  <a href="http://lunch.js.la/">lunch.js</a> is on the first Tuesday of every month (you can also host your own by creating an <a href="https://github.com/jsla/lunch.js/issues">issue</a> on the <a href="https://github.com/jsla/lunch.js">lunch.js repo</a> with our handy <a href="https://github.com/jsla/lunch.js/blob/master/ISSUE_TEMPLATE.md">issue template</a>.
+        h3#whenIsJsla When is js.la?
+        p The main event is always on the last Thursday of every month! You can always go to our homepage at <a href="/">js.la</a> to find out about the next one.
+        p <a href="https://nodeschool.io/los-angeles/">NodeSchool</a> is on the first Saturday of every month.
+        p  <a href="http://lunch.js.la/">lunch.js</a> is on the first Tuesday of every month (you can also host your own by creating an <a href="https://github.com/jsla/lunch.js/issues">issue</a> on the <a href="https://github.com/jsla/lunch.js">lunch.js repo</a> with our handy <a href="https://github.com/jsla/lunch.js/blob/master/ISSUE_TEMPLATE.md">issue template</a>.
 
-    h3#butHow But <i>HOW</i> can this be?
-    p The main event is always on the last Thursday of every month! You can always go to our homepage at <a href="/">js.la</a> to find out about the next one.
+        h3#butHow But <i>HOW</i> can this be?
+        p The main event is always on the last Thursday of every month! You can always go to our homepage at <a href="/">js.la</a> to find out about the next one.
 
-    h3#whatToExpect What should I expect if I attend?
-    p We usually start off with some general mingling gathered around some type of fancy finger foods and refreshments (often alcoholic and always with non alcoholic options) or the everloved pizza. Once everything is set up and ready to go we make announcements and give an outline of the gala you're in for. When the gracious hosts and sponsors have given a kind word in addition to their hospitality it's off the races! One action packed talk, then a much needed reprieve to recoup and recover and before you know it BOOM!💣💥 ANOTHER TALK! This is all followed by a crowd favorite with <a href="/drinks">drinks.js</a> where we venture into the wilderness and reconviene at the nearest and most obscure watering holes in Los Angeles. Don't be surprised if you see superstars like Andy Dick or Pauly Shore hanging around! They're 'people' just like the rest of us.
+        h3#whatToExpect What should I expect if I attend?
+        p We usually start off with some general mingling gathered around some type of fancy finger foods and refreshments (often alcoholic and always with non alcoholic options) or the everloved pizza. Once everything is set up and ready to go we make announcements and give an outline of the gala you're in for. When the gracious hosts and sponsors have given a kind word in addition to their hospitality it's off the races! One action packed talk, then a much needed reprieve to recoup and recover and before you know it BOOM!💣💥 ANOTHER TALK! This is all followed by a crowd favorite with <a href="/drinks">drinks.js</a> where we venture into the wilderness and reconviene at the nearest and most obscure watering holes in Los Angeles. Don't be surprised if you see superstars like Andy Dick or Pauly Shore hanging around! They're 'people' just like the rest of us.
 
-    h3#rsvp How can I RSVP to an upcoming event?
-    p The best way is to get on our <a href="http://us4.list-manage.com/subscribe?u=bb39146d31da3313db866eca6&id=2daf1a7bee">mailing list</a> as tickets tend to get reserved within minutes. We use <a href="https://ti.to/jsla/">ti.to</a> for ticket reservations and kindly ask that if you reserve a seat to please fill it or release your ticket. We have a <a href="https://www.meetup.com/Los-Angeles-JavaScript-and-Node-js/">meetup</a> page as well but we primarily track tickets via ti.to mentioned prior.
-    p We make tickets to our event available in two places. A portion are reserved for Meetup. The rest are reserved on our ticketing platform <a href="https://ti.to/jsla/">ti.to</a>.
+        h3#rsvp How can I RSVP to an upcoming event?
+        p The best way is to get on our <a href="http://us4.list-manage.com/subscribe?u=bb39146d31da3313db866eca6&id=2daf1a7bee">mailing list</a> as tickets tend to get reserved within minutes. We use <a href="https://ti.to/jsla/">ti.to</a> for ticket reservations and kindly ask that if you reserve a seat to please fill it or release your ticket. We have a <a href="https://www.meetup.com/Los-Angeles-JavaScript-and-Node-js/">meetup</a> page as well but we primarily track tickets via ti.to mentioned prior.
+        p We make tickets to our event available in two places. A portion are reserved for Meetup. The rest are reserved on our ticketing platform <a href="https://ti.to/jsla/">ti.to</a>.
 
 
-    h3#waitlist What if I'm on the waitlist?
-    p Many people from the waitlist do get a ticket so do check back closer to the event. There tends to be a lot of cancelations before the event. Unfortunately, since we have limited space at the venue, we can't admit people without a ticket from <a href="https://ti.to/jsla/">ti.to</a> or Meetup RSVP.
-    p Our events tend to sell out very quickly (sometimes from within minutes to within hours). The best way to get a ticket is to join our <a href="http://us4.list-manage.com/subscribe?u=bb39146d31da3313db866eca6&id=2daf1a7bee">mailing list</a> where we announce each event.
+        h3#waitlist What if I'm on the waitlist?
+        p Many people from the waitlist do get a ticket so do check back closer to the event. There tends to be a lot of cancelations before the event. Unfortunately, since we have limited space at the venue, we can't admit people without a ticket from <a href="https://ti.to/jsla/">ti.to</a> or Meetup RSVP.
+        p Our events tend to sell out very quickly (sometimes from within minutes to within hours). The best way to get a ticket is to join our <a href="http://us4.list-manage.com/subscribe?u=bb39146d31da3313db866eca6&id=2daf1a7bee">mailing list</a> where we announce each event.
 
-    h3#howCanIParticipate How can I participate in an event as a Speaker/Host/Sponsor?
-    p If you have to ask you'll never know. Just kidding! We have a page dedicated specifically for this and especially for you! Visit <a href="http://contribute.js.la/">contribute.js.la</a> and choose the appropriate option to fill out a short form to get started. Someone will reach out to you very soon afterwards and thank you in advance for the inerest!
+        h3#howCanIParticipate How can I participate in an event as a Speaker/Host/Sponsor?
+        p If you have to ask you'll never know. Just kidding! We have a page dedicated specifically for this and especially for you! Visit <a href="http://contribute.js.la/">contribute.js.la</a> and choose the appropriate option to fill out a short form to get started. Someone will reach out to you very soon afterwards and thank you in advance for the inerest!
 
-    h3#CoC Is there a code of conduct?
-    p We're so glad you asked! We absolutely have a CoC so as to make everyone feel very welcome and inclusive of meeting new people and making new friends in the name of the almighty JavaScript Overlords. It can be found <a href="/code-of-conduct">here</a>
-    hr
+        h3#CoC Is there a code of conduct?
+        p We're so glad you asked! We absolutely have a CoC so as to make everyone feel very welcome and inclusive of meeting new people and making new friends in the name of the almighty JavaScript Overlords. It can be found <a href="/code-of-conduct">here</a>
+        hr

--- a/public/sponsorship.jade
+++ b/public/sponsorship.jade
@@ -1,22 +1,23 @@
-div.jsla-toplevel-container.jsla-content-page.jsla-content-section.layer-2
-    h1 Want to sponsor js.la?
-    p We would love to have your company join the js.la community!
-    h2 What you get.
-    ul
-        li Opportunity to introduce your company to the attendees
-        li Company logo or custom slide on display throughout the event
-        li Company logo on all videos recorded that month
-        li Company logo on website with link
-        li Mention + link in email to full email list + on meetup announce/event page
-        li Tweets leading up to the event and after
+div.jsla-toplevel-container.jsla-content-page
+    div.jsla-content-section.layer-2
+      h1 Want to sponsor js.la?
+      p We would love to have your company join the js.la community!
+      h2 What you get.
+      ul
+          li Opportunity to introduce your company to the attendees
+          li Company logo or custom slide on display throughout the event
+          li Company logo on all videos recorded that month
+          li Company logo on website with link
+          li Mention + link in email to full email list + on meetup announce/event page
+          li Tweets leading up to the event and after
 
-    div(class="u-textAlign--center")
-        form(action='https://www.paypal.com/cgi-bin/webscr', method='post', target='_top')
-              input(type='hidden', name='cmd', value='_s-xclick')
-              input(type='hidden', name='hosted_button_id', value='KXHWRLKYRXRHL')
-              button(type='submit', class='pure-button-secondary pure-button jsla-button-xlarge', name='submit', alt='PayPal - The safer, easier way to pay online!') Sponsor js.la
-              img(alt='', border='0', src='https://www.paypalobjects.com/en_US/i/scr/pixel.gif', width='1', height='1')
-    p
+      div(class="u-textAlign--center")
+          form(action='https://www.paypal.com/cgi-bin/webscr', method='post', target='_top')
+                input(type='hidden', name='cmd', value='_s-xclick')
+                input(type='hidden', name='hosted_button_id', value='KXHWRLKYRXRHL')
+                button(type='submit', class='pure-button-secondary pure-button jsla-button-xlarge', name='submit', alt='PayPal - The safer, easier way to pay online!') Sponsor js.la
+                img(alt='', border='0', src='https://www.paypalobjects.com/en_US/i/scr/pixel.gif', width='1', height='1')
+      p
 
 div.jsla-toplevel-container.jsla-content-page
     h4 Companies that have sponsored js.la


### PR DESCRIPTION
Changes to make spacing and margins more consistent across site. The CoC page has the nicest spacing.

Sponsorship page:
Old Margins and Spacing:
![screen shot 2017-05-25 at 3 08 32 pm](https://cloud.githubusercontent.com/assets/9439906/26472717/2e155874-415c-11e7-9459-d8c92ae0dbd9.png)
New Margins and Spacing: 
![screen shot 2017-05-25 at 3 08 45 pm](https://cloud.githubusercontent.com/assets/9439906/26472725/371e3940-415c-11e7-969f-cd804e4a55a3.png)

Faq Page:
Old FAQ page:
![screen shot 2017-05-25 at 3 11 14 pm](https://cloud.githubusercontent.com/assets/9439906/26472777/733de86c-415c-11e7-95fc-135f7a848c64.png)
New FAQ page with consistent background:
![screen shot 2017-05-25 at 3 10 47 pm](https://cloud.githubusercontent.com/assets/9439906/26472788/7f1575a6-415c-11e7-94b4-06d292baad4a.png)

