### PR TITLE
update to vanity url with tracking

### DIFF
--- a/public/_data.json
+++ b/public/_data.json
@@ -45,7 +45,7 @@
             "url": "https://www.headspace.com/join-us"
           }
       ],
-      "titoUrl": "https://www.eventbrite.com/e/august-2017-registration-36130641722?aff=site",
+      "titoUrl": "https://jsla.eventbrite.com/?aff=site",
       "heroPhotos": "https://api.flickr.com/services/rest/?method=flickr.photos.search&api_key=cdab964aa20adf96aabd31cc07e6cd57&tags=JSLA&max_taken_date=2014-10-31&min_taken_date=2014-10-29&format=json"
     },
     "sitemap": {


### PR DESCRIPTION
the key for this item is still `titoUrl`, should this be updated?