### PR TITLE
Automate Video Card Creation

### DIFF
--- a/public/video-cards/_layout.jade
+++ b/public/video-cards/_layout.jade
@@ -1,0 +1,9 @@
+html
+  head
+    link(rel='stylesheet', href='video.css')
+  body
+    .card
+      != yield
+    .logo
+    
+  

--- a/public/video-cards/speaker.jade
+++ b/public/video-cards/speaker.jade
@@ -1,0 +1,17 @@
+- var speaker = public.events['2017']._data.events[0].speakers[0]
+
+script
+  != 'console.log(' + JSON.stringify(speaker) + ')'
+
+.speaker
+  .avatar
+    img(src='/images/speakers/' + speaker.image)
+  .info
+    h1= speaker.name
+    
+    h2= speaker.title
+    
+    .twitter= speaker.twitter
+    
+    .github= speaker.github
+    

--- a/public/video-cards/sponsors.jade
+++ b/public/video-cards/sponsors.jade
@@ -1,0 +1,8 @@
+- var sponsors = public.events['2017']._data.events[0].sponsors
+
+script
+  != 'console.log(' + JSON.stringify(sponsors) + ')'
+
+each sponsor in sponsors
+  .sponsor
+    img(src='/images/hosts/' + sponsor.logo)

--- a/public/video-cards/video.css
+++ b/public/video-cards/video.css
@@ -1,0 +1,30 @@
+html, body {
+  padding: 0;
+  margin: 0;
+}
+
+.logo {
+  position: absolute;
+  left: 1685px;
+  top: 848px;
+  width: 220px;
+  height: 220px;
+  background: #f5dd3d;
+  background-image: url(/images/logo.svg);
+  background-repeat: no-repeat;
+  background-position: center;
+  box-shadow: 25px 25px 25px rgba(0, 0, 0, 0.40);
+}
+
+.card {
+  width: 1920px;
+  height: 1080px;
+  background: #fff08a;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.sponsor {
+  box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.25);
+}


### PR DESCRIPTION
Currently our videos require some tedious manual work to create the intro/title cards for sponsors and speakers. Examples below.

The purpose of this PR is to create them with the data/images available in the site repo -- saving lots of human time. We can either use something like Firefox's screenshot function or Puppeteer to convert the pages to images.

Example speaker title card:

![image](https://user-images.githubusercontent.com/431696/34228455-980f1364-e585-11e7-9896-2875a2deea5f.png)

HTML version created with this PR:

![image](https://user-images.githubusercontent.com/431696/34228478-acd1f262-e585-11e7-9d6e-6da4966d9677.png)
