### PR TITLE
Update drinks.js and js.la/next for September 2018

### DIFF
--- a/public/_data.json
+++ b/public/_data.json
@@ -10,10 +10,10 @@
             "misc": ""
         },
         "drinksjs": {
-            "address": null,
-            "name": null,
+            "address": "116 Santa Monica Blvd, Santa Monica, CA 90401",
+            "name": "Ye Olde Kings Head",
             "misc": null,
-            "url": null
+            "url": "https://www.yelp.com/biz/ye-olde-kings-head-santa-monica"
         },
         "speakers": [
             {

--- a/public/next.jade
+++ b/public/next.jade
@@ -1,2 +1,2 @@
 script.
-  window.location.href = 'https://jsla-september-2018.eventbrite.com'
+  window.location.href = 'https://jsla-next.eventbrite.com'


### PR DESCRIPTION
Updates drinks location
Changes the js.la/next redirect to a generic URL that can be reused every month