### PR TITLE
Tweaks various styling of headlines/body copy

### DIFF
--- a/public/_partials/cta.ejs
+++ b/public/_partials/cta.ejs
@@ -1,9 +1,12 @@
 <section id="cta">
-  <header>
+  <header class="container">
     <h2>Want to present, host, or sponsor?</h2>
-    <p>Head to <a href="https://contribute.js.la/">contribute.js.la</a> and fill out the relevant form! We will get back to you as soon as we can. Also,
-       feel free to hit us up on Twitter with questions, 
-      <a href="https://twitter.com/jsdotla">@jsdotla</a>. We are always looking for more talks for future events. If you want to present, let us know!</p>
+    <p>
+      Head to <a href="https://contribute.js.la/">contribute.js.la</a> and fill out the relevant
+      form! We will get back to you as soon as we can. Also, feel free to hit us up on Twitter with
+      questions, <a href="https://twitter.com/jsdotla">@jsdotla</a>. We are always looking for more
+      talks for future events. If you want to present, let us know!
+    </p>
   </header>
   <footer>
     <ul class="buttons">

--- a/public/_partials/speakers.ejs
+++ b/public/_partials/speakers.ejs
@@ -1,43 +1,25 @@
-<script>
-    function switchSpeakersDescriptionLength(i){
-        if($("#text-less"+i.toString()).attr('hidden') == "hidden"){
-            $("#text-less"+i.toString()).removeAttr('hidden')
-            $("#read-more-less-button"+i).text("Read more")
-        }else{
-            $("#text-less"+i.toString()).attr('hidden', "hidden")
-            $("#read-more-less-button"+i).text("Read less")
-        }
-        if($("#text-more"+i.toString()).attr('hidden') == "hidden"){
-            $("#text-more"+i.toString()).removeAttr('hidden')
-        }else{
-            $("#text-more"+i.toString()).attr('hidden', "hidden")
-        }
-        
-    }
-</script>
-
 <section class="wrapper style1 container special">
-    <h1 style="font-weight: bold; font-size: 28px;">Speakers</h1>    
+    <h1 style="font-weight: bold; font-size: 42px;">Speakers</h1>
     <div class="row" id="speakers">
-        <% for(var i=0;i<event.speakers.length;i++){ 
+        <% for(var i=0;i<event.speakers.length;i++){
             let speaker = public._data.speakers[event.speakers[i]]; %>
             <div class="col-6 col-12-narrower speaker">
             <section>
-                <span><img class="speaker-photo" src="<%= speaker.image %>" /></span>
-                <span><h4 style="font-weight: bold"><%= speaker.name %>
-                    <a href="https://www.github.com/<%= speaker.github %>"><span class="icon fa-github" style="color: #050505"></span></a>
-                    <a href="https://www.twitter.com/<%= speaker.twitter %>"><span class="icon fa-twitter" style="color: #01B9FF"></span></a>
-                </h4></span>
+                <h4><img class="speaker-photo" src="<%= speaker.image %>" />
+                    <div class="speaker-details">
+                        <%= speaker.name %>
+                        <div class="speaker-links">
+                            <a href="https://www.github.com/<%= speaker.github %>"><span class="icon fa-github" style="color: #050505"></span></a>
+                            <a href="https://www.twitter.com/<%= speaker.twitter %>"><span class="icon fa-twitter" style="color: #01B9FF"></span></a>
+                        </div>
+                    </div>
+                </h4>
                 <header><h3 class="speaker-description"><%= speaker.title %></h3></header>
-                <p id="text-less<%= i %>" class="speaker-abstract">
-                <%= speaker.description.substring(0, 100)+(speaker.description.length>100?"...":"") %>    
-                <p id="text-more<%= i %>" class="speaker-abstract" hidden=1>
+                <p id="text-more" class="speaker-abstract">
                 <%= speaker.description %>
                 </p>
-                <button id="read-more-less-button<%= i %>" onclick=switchSpeakersDescriptionLength(<%= i %>)>Read more</button>
             </section>
             </div>
             <% } %>
         </div>
         </section>
-        

--- a/public/assets/css/custom.css
+++ b/public/assets/css/custom.css
@@ -19,7 +19,8 @@ a{
 }
 
 .jsla-hero-speakers .jsla-speaker .jsla-speaker-details {
-    margin-left: 70px
+    margin-left: 60px;
+    min-height: 71px;
 }
 
 .jsla-hero-speakers .jsla-speaker .jsla-avatar {
@@ -31,10 +32,10 @@ a{
 }
 
 .jsla-hero-speakers .jsla-speaker h1,.jsla-hero-speakers .jsla-speaker h2 {
-    line-height: 35px;
+    line-height: 30px;
     margin: 0;
     font-size: 1em;
-    padding: 0 1em;
+    padding: 0.1em 1em;
     font-weight: 500;
     text-align: left;
     overflow: hidden;
@@ -44,7 +45,10 @@ a{
 
 .jsla-hero-speakers .jsla-speaker h2 {
     color: #969696;
-    font-size: 1em
+    font-size: 1em;
+}
+.jsla-hero-speakers .jsla-speaker h1 {
+    margin-top: -10px;
 }
 
 .jsla-sponsors{
@@ -86,17 +90,36 @@ a{
         margin-top: 80px;
     }
 }
+div.speaker > section {
+    text-align: initial !important;
+    padding: 50px 50px 0;
+}
 .speaker-photo{
     width: 100px;
     border-radius: 50%;
+    display: inline-block;
 }
-
+.speaker-links {
+  display: block
+}
+.speaker-details {
+    display: inline-block;
+    vertical-align: top;
+    padding-left: 20px;
+    text-align: left;
+}
+.speaker-details a > span {
+    font-size: 28px !important;
+    margin-right: 5px;
+}
 .speaker-description{
-    height: 70px;
+    text-align: left;
     line-height: 22px;
+    font-weight: 600;
 }
 .speaker-abstract{
     min-height: 80px;
+    text-align: left !important;
 }
 .row{
     margin-left: auto;

--- a/public/events/_events.ejs
+++ b/public/events/_events.ejs
@@ -1,21 +1,5 @@
 <% include ../_helpers.ejs %>
-<script>
-    function switchSpeakersDescriptionLength(i) {
-        if ($("#text-less" + i.toString()).attr('hidden') == "hidden") {
-            $("#text-less" + i.toString()).removeAttr('hidden')
-            $("#read-more-less-button" + i).text("Read more")
-        } else {
-            $("#text-less" + i.toString()).attr('hidden', "hidden")
-            $("#read-more-less-button" + i).text("Read less")
-        }
-        if ($("#text-more" + i.toString()).attr('hidden') == "hidden") {
-            $("#text-more" + i.toString()).removeAttr('hidden')
-        } else {
-            $("#text-more" + i.toString()).attr('hidden', "hidden")
-        }
 
-    }
-</script>
 <header class="special container">
     <span class="icon fa-laptop"></span>
     <h2>Presentations from
@@ -23,7 +7,7 @@
     </h2>
 </header>
 <% for(var j=0;j<public._data.events.length;j++){
-    let event = public._data.events[j]; 
+    let event = public._data.events[j];
     if(new Date(event.date).getYear()+1900!=year)continue;
     %>
 <section class="wrapper style3 container special">
@@ -35,12 +19,14 @@
                 let speaker = public._data.speakers[event.speakers[i]]; %>
         <div class="col-6 col-12-narrower speaker">
             <section>
-                <span><img class="speaker-photo" src="<%= pathToUrl(speaker.image) %>" /></span>
-                <span>
+                <span style="display: inline-block;"><img class="speaker-photo" src="<%= pathToUrl(speaker.image) %>" /></span>
+                <span style="display: inline-block; vertical-align: top; padding-left: 10px">
                     <h4>
                         <%= speaker.name %>
-                        <a href="https://www.github.com/<%= speaker.github %>"><span class="icon fa-github" style="color: #050505"></span></a>
+                        <div style="display: block"><a href="https://www.github.com/<%= speaker.github %>"><span class="icon fa-github"
+                                style="color: #050505"></span></a>
                         <a href="https://www.twitter.com/<%= speaker.twitter %>"><span class="icon fa-twitter" style="color: #01B9FF"></span></a>
+                        </div>
                     </h4>
                 </span>
                 <header>
@@ -48,14 +34,9 @@
                         <%= speaker.title %>
                     </h3>
                 </header>
-                <% if(speaker.description){ %>
-                <p id="text-less<%=i%>-<%=j%>" class="speaker-abstract">
-                    <%= speaker.description.substring(0, 100)+(speaker.description.length>100?"...":"") %>
-                    <p id="text-more<%=i%>-<%=j%>" class="speaker-abstract" hidden=1>
+                    <p id="text-more" class="speaker-abstract">
                         <%= speaker.description %>
-                    </p><%}%>
-                    <button id="read-more-less-button<%=i%>-<%=j%>" onclick=switchSpeakersDescriptionLength("<%=i%>-<%=j%>")>Read
-                        more</button>
+                    </p
                     <% if(pathToUrl(speaker.video) && speaker.video.indexOf("vimeo")==-1){ %>
                     <a href="<%= pathToUrl(speaker.video) %>" data-lity class="jsla-video-container"><img src="<%=pathToUrl(speaker.videoimg)%>"
                             class="videoimg"></a>


### PR DESCRIPTION
- tightens up spacing between upcoming event speakers namers and talk
titles
- caps width of body content in all pages to 960px for legibility of
longer copy
- removes 'Read More' buttons in favor of showing all copy upfront
- larger 'SPEAKERS' header text
- split speaker name and social links onto two lines to the right of
photo
- left align speaker info

TODO:
- [ ] some past speakers are missing entirely or only pieces of info.
- [ ] lots of code needs to be cleaned up as the template has a lot of
extra garbage we don't need.
- [ ] sponsors listed twice
- [ ] event text up top could be cleaner or include host logo?