### PR TITLE
Add space to CoC for legibility

### DIFF
--- a/public/code-of-conduct.ejs
+++ b/public/code-of-conduct.ejs
@@ -18,7 +18,7 @@
     </div>
   
     <footer class="major">
-            <p><span style="color: red">&lt;3</span><span>The js.la Team</span></p><a href="mailto:all@js.la">all@js.la</a>
+            <p><span style="color: red">&lt;3</span> <span>The js.la Team</span></p><a href="mailto:all@js.la">all@js.la</a>
     </footer>
   </section>
   


### PR DESCRIPTION
This PR adds a space between the red heart (`<3`) and "The js.la Team" on the _Code of Conduct_ page for improved legibility.